### PR TITLE
[Typesystem] fix count_var and count_fun

### DIFF
--- a/pyrser/type_system/fun.py
+++ b/pyrser/type_system/fun.py
@@ -50,6 +50,10 @@ class Fun(Signature):
             if p.is_polymorphic:
                 return True
 
+    @property
+    def is_fun(self) -> bool:
+        return True
+
     def internal_name(self):
         """
         Return the unique internal name

--- a/pyrser/type_system/scope.py
+++ b/pyrser/type_system/scope.py
@@ -101,7 +101,7 @@ class Scope(Symbol):
         """ Count var define by this scope """
         n = 0
         for s in self._hsig.values():
-            if hasattr(s, 'is_var') and s.is_var():
+            if hasattr(s, 'is_var') and s.is_var:
                 n += 1
         return n
 
@@ -109,7 +109,7 @@ class Scope(Symbol):
         """ Count function define by this scope """
         n = 0
         for s in self._hsig.values():
-            if hasattr(s, 'is_fun') and s.is_fun():
+            if hasattr(s, 'is_fun') and s.is_fun:
                 n += 1
         return n
 

--- a/pyrser/type_system/var.py
+++ b/pyrser/type_system/var.py
@@ -18,6 +18,10 @@ class Var(Signature):
     def is_polymorphic(self) -> bool:
         return self.tret.is_polymorphic
 
+    @property
+    def is_var(self) -> bool:
+        return True
+
     def internal_name(self):
         """
         Return the unique internal name


### PR DESCRIPTION
In the Typesystem, the two functions count_var and count_fun doesn't works because the property theses function are looking at doesn't exists in Var() and Fun(). Add theses properties in Fun() and Var().